### PR TITLE
MCOL-5477 Disk join step improvement.

### DIFF
--- a/dbcon/joblist/diskjoinstep.cpp
+++ b/dbcon/joblist/diskjoinstep.cpp
@@ -163,7 +163,6 @@ void DiskJoinStep::smallReader()
   RGData rgData;
   bool more = true;
   int64_t memUsage = 0, combinedMemUsage = 0;
-  [[maybe_unused]] int rowCount = 0;
   RowGroup l_smallRG = smallRG;
 
   try
@@ -175,7 +174,6 @@ void DiskJoinStep::smallReader()
       if (more)
       {
         l_smallRG.setData(&rgData);
-        rowCount += l_smallRG.getRowCount();
         memUsage = jp->insertSmallSideRGData(rgData);
         combinedMemUsage = atomicops::atomicAdd(smallUsage.get(), memUsage);
 
@@ -224,7 +222,6 @@ void DiskJoinStep::largeReader()
   RGData rgData;
   bool more = true;
   int64_t largeSize = 0;
-  [[maybe_unused]] int rowCount = 0;
   RowGroup l_largeRG = largeRG;
 
   largeIterationCount++;
@@ -239,7 +236,6 @@ void DiskJoinStep::largeReader()
       if (more)
       {
         l_largeRG.setData(&rgData);
-        rowCount += l_largeRG.getRowCount();
         // cout << "large side raw data: " << largeRG.toString() << endl;
 
         largeSize += jp->insertLargeSideRGData(rgData);
@@ -268,22 +264,86 @@ void DiskJoinStep::largeReader()
 void DiskJoinStep::loadFcn()
 {
   boost::shared_ptr<LoaderOutput> out;
-  bool ret;
+  std::vector<JoinPartition*> joinPartitions;
+  // Collect all join partitions.
+  jp->collectJoinPartitions(joinPartitions);
+
+#ifdef DEBUG_DJS
+  cout << "Collected join partitions: " << endl;
+  for (uint32_t i = 0; i < joinPartitions.size(); ++i)
+    cout << joinPartitions[i]->getUniqueID() << ", ";
+  cout << endl;
+#endif
 
   try
   {
-    do
-    {
-      out.reset(new LoaderOutput());
-      ret = jp->getNextPartition(&out->smallData, &out->partitionID, &out->jp);
+    uint32_t partitionIndex = 0;
+    bool partitionDone = true;
 
-      if (ret)
+    // Iterate over partitions.
+    while (partitionIndex < joinPartitions.size() && !cancelled())
+    {
+      uint64_t currentSize = 0;
+      auto* joinPartition = joinPartitions[partitionIndex];
+      out.reset(new LoaderOutput());
+
+      if (partitionDone)
+        joinPartition->setNextSmallOffset(0);
+
+      while (true)
       {
-        // cout << "loaded partition " << out->partitionID << " smallData = " << out->smallData.size() <<
-        // endl;
-        loadFIFO->insert(out);
+        messageqcpp::ByteStream bs;
+        RowGroup rowGroup;
+        RGData rgData;
+
+        joinPartition->readByteStream(0, &bs);
+        if (!bs.length())
+        {
+          partitionDone = true;
+          break;
+        }
+
+        rgData.deserialize(bs);
+        rowGroup.setData(&rgData);
+
+        // Check that current `RowGroup` has rows.
+        if (!rowGroup.getRowCount())
+        {
+          partitionDone = true;
+          break;
+        }
+
+        // TODO: Add proper estimation, for string as well.
+        currentSize += (64 * rowGroup.getRowCount());
+        out->smallData.push_back(rgData);
+
+        if (currentSize > partitionSize)
+        {
+#ifdef DEBUG_DJS
+          cout << "Memory limit exceeded for the partition: " << joinPartition->getUniqueID() << endl;
+          cout << "Current size: " << currentSize << " Memory limit: " << partitionSize << endl;
+#endif
+          partitionDone = false;
+          break;
+        }
       }
-    } while (ret && !cancelled());
+
+      if (!out->smallData.size())
+      {
+        ++partitionIndex;
+        partitionDone = true;
+        continue;
+      }
+
+      // Initialize `LoaderOutput` and add it to `FIFO`.
+      out->partitionID = joinPartition->getUniqueID();
+      out->jp = joinPartition;
+      loadFIFO->insert(out);
+
+      // If this partition is done - take a next one.
+      if (partitionDone)
+        ++partitionIndex;
+    }
   }
   catch (...)
   {

--- a/dbcon/joblist/jlf_tuplejoblist.cpp
+++ b/dbcon/joblist/jlf_tuplejoblist.cpp
@@ -1841,7 +1841,7 @@ void CircularJoinGraphTransformer::chooseEdgeToTransform(Cycle& cycle,
     std::cout << "FK FK key not found, removing the first one inner join edge" << std::endl;
 
   // Take just a first.
-  resultEdge = std::make_pair(cycle.front(), 0 /*Dummy weight*/);
+  resultEdge = std::make_pair(cycle.back(), 0 /*Dummy weight*/);
 }
 
 void CircularJoinGraphTransformer::removeAssociatedHashJoinStepFromJoinSteps(const JoinEdge& joinEdge)

--- a/dbcon/joblist/tuplehashjoin.cpp
+++ b/dbcon/joblist/tuplehashjoin.cpp
@@ -116,6 +116,12 @@ TupleHashJoinStep::TupleHashJoinStep(const JobInfo& jobInfo)
   else
     allowDJS = false;
 
+  string forceDiskBasedJoinStr = config->getConfig("HashJoin", "ForceDiskBasedJoin");
+  if (allowDJS && (forceDiskBasedJoinStr == "y" || forceDiskBasedJoinStr == "Y"))
+    forceDiskBasedJoin = true;
+  else
+    forceDiskBasedJoin = false;
+
   numCores = resourceManager->numCores();
   if (numCores <= 0)
     numCores = 8;
@@ -1955,53 +1961,69 @@ void TupleHashJoinStep::segregateJoiners()
     return;
   }
 
-  /* If they are all inner joins they can be segregated w/o respect to
-  ordering; if they're not, the ordering has to stay consistent therefore
-  the first joiner that isn't finished and everything after has to be
-  done by DJS. */
-
-  if (allInnerJoins)
+  // Force all joins into disk based.
+  if (forceDiskBasedJoin)
   {
-    for (i = 0; i < smallSideCount; i++)
+    for (i = 0; i < smallSideCount; ++i)
     {
-      // if (joiners[i]->isFinished() && (rand() % 2)) {    // for debugging
-      if (joiners[i]->isFinished())
-      {
-        // cout << "1joiner " << i << "  " << hex << (uint64_t) joiners[i].get() << dec << " -> TBPS" << endl;
-        tbpsJoiners.push_back(joiners[i]);
-      }
-      else
-      {
-        joinIsTooBig = true;
-        joiners[i]->setConvertToDiskJoin();
-        // cout << "1joiner " << i << "  " << hex << (uint64_t) joiners[i].get() << dec << " -> DJS" << endl;
-        djsJoiners.push_back(joiners[i]);
-        djsJoinerMap.push_back(i);
-      }
+      joinIsTooBig = true;
+      joiners[i]->setConvertToDiskJoin();
+      djsJoiners.push_back(joiners[i]);
+      djsJoinerMap.push_back(i);
     }
   }
   else
   {
-    // uint limit = rand() % smallSideCount;
-    for (i = 0; i < smallSideCount; i++)
+    /* If they are all inner joins they can be segregated w/o respect to
+    ordering; if they're not, the ordering has to stay consistent therefore
+    the first joiner that isn't finished and everything after has to be
+    done by DJS. */
+    if (allInnerJoins)
     {
-      // if (joiners[i]->isFinished() && i < limit) {  // debugging
-      if (joiners[i]->isFinished())
+      for (i = 0; i < smallSideCount; i++)
       {
-        // cout << "2joiner " << i << "  " << hex << (uint64_t) joiners[i].get() << dec << " -> TBPS" << endl;
-        tbpsJoiners.push_back(joiners[i]);
+        // if (joiners[i]->isFinished() && (rand() % 2)) {    // for debugging
+        if (joiners[i]->isFinished())
+        {
+          // cout << "1joiner " << i << "  " << hex << (uint64_t) joiners[i].get() << dec << " -> TBPS" <<
+          // endl;
+          tbpsJoiners.push_back(joiners[i]);
+        }
+        else
+        {
+          joinIsTooBig = true;
+          joiners[i]->setConvertToDiskJoin();
+          // cout << "1joiner " << i << "  " << hex << (uint64_t) joiners[i].get() << dec << " -> DJS" <<
+          // endl;
+          djsJoiners.push_back(joiners[i]);
+          djsJoinerMap.push_back(i);
+        }
       }
-      else
-        break;
     }
-
-    for (; i < smallSideCount; i++)
+    else
     {
-      joinIsTooBig = true;
-      joiners[i]->setConvertToDiskJoin();
-      // cout << "2joiner " << i << "  " << hex << (uint64_t) joiners[i].get() << dec << " -> DJS" << endl;
-      djsJoiners.push_back(joiners[i]);
-      djsJoinerMap.push_back(i);
+      // uint limit = rand() % smallSideCount;
+      for (i = 0; i < smallSideCount; i++)
+      {
+        // if (joiners[i]->isFinished() && i < limit) {  // debugging
+        if (joiners[i]->isFinished())
+        {
+          // cout << "2joiner " << i << "  " << hex << (uint64_t) joiners[i].get() << dec << " -> TBPS" <<
+          // endl;
+          tbpsJoiners.push_back(joiners[i]);
+        }
+        else
+          break;
+      }
+
+      for (; i < smallSideCount; i++)
+      {
+        joinIsTooBig = true;
+        joiners[i]->setConvertToDiskJoin();
+        // cout << "2joiner " << i << "  " << hex << (uint64_t) joiners[i].get() << dec << " -> DJS" << endl;
+        djsJoiners.push_back(joiners[i]);
+        djsJoinerMap.push_back(i);
+      }
     }
   }
 }

--- a/dbcon/joblist/tuplehashjoin.h
+++ b/dbcon/joblist/tuplehashjoin.h
@@ -622,6 +622,7 @@ class TupleHashJoinStep : public JobStep, public TupleDeliveryStep
   uint64_t djsPartitionSize;
   bool isDML;
   bool allowDJS;
+  bool forceDiskBasedJoin;
 
   // hacky mechanism to prevent nextBand from starting before the final
   // THJS configuration is settled.  Debatable whether to use a bool and poll instead;

--- a/oam/etc/Columnstore.xml
+++ b/oam/etc/Columnstore.xml
@@ -189,6 +189,7 @@
 		<TotalUmMemory>25%</TotalUmMemory>
 		<CPUniqueLimit>100</CPUniqueLimit>
 		<AllowDiskBasedJoin>N</AllowDiskBasedJoin>
+		<ForceDiskBasedJoin>N</ForceDiskBasedJoin>
 		<TempFileCompression>Y</TempFileCompression>
 		<TempFileCompressionType>Snappy</TempFileCompressionType> <!-- LZ4, Snappy -->
 	</HashJoin>

--- a/utils/joiner/joinpartition.cpp
+++ b/utils/joiner/joinpartition.cpp
@@ -34,6 +34,7 @@ using namespace logging;
 
 namespace joiner
 {
+// FIXME: Possible overflow, we have to null it after clearing files.
 uint64_t uniqueNums = 0;
 
 JoinPartition::JoinPartition()
@@ -54,6 +55,7 @@ JoinPartition::JoinPartition(const RowGroup& lRG, const RowGroup& sRG, const vec
  , htSizeEstimate(0)
  , htTargetSize(partitionSize)
  , rootNode(true)
+ , canSplit(true)
  , antiWithMatchNulls(antiWMN)
  , needsAllNullRows(hasFEFilter)
  , gotNullRow(false)
@@ -131,6 +133,7 @@ JoinPartition::JoinPartition(const JoinPartition& jp, bool splitMode)
  , htSizeEstimate(0)
  , htTargetSize(jp.htTargetSize)
  , rootNode(false)
+ , canSplit(true)
  , antiWithMatchNulls(jp.antiWithMatchNulls)
  , needsAllNullRows(jp.needsAllNullRows)
  , gotNullRow(false)
@@ -145,13 +148,6 @@ JoinPartition::JoinPartition(const JoinPartition& jp, bool splitMode)
   ostringstream os;
 
   fileMode = true;
-  // tuning issue: with the defaults, each 100MB bucket would split s.t. the children
-  // could store another 4GB total.  Given a good hash and evenly distributed data,
-  // the first level of expansion would happen for all JPs at once, giving a total
-  // capacity of (4GB * 40) = 160GB, when actual usage at that point is a little over 4GB.
-  // Instead, each will double in size, giving a capacity of 8GB -> 16 -> 32, and so on.
-  //	bucketCount = jp.bucketCount;
-  bucketCount = 2;
   config::Config* config = config::Config::makeConfig();
   filenamePrefix = config->getTempFileDir(config::Config::TempDirPurpose::Joins);
 
@@ -270,9 +266,6 @@ int64_t JoinPartition::doneInsertingSmallData()
       smallSizeOnDisk += leafNodeIncrement;
     }
 
-  // else
-  //	cout << uniqueID << " htsizeestimate = " << htSizeEstimate << endl;
-
   if (!rootNode)
   {
     buffer.reinit(largeRG);
@@ -314,24 +307,89 @@ int64_t JoinPartition::doneInsertingLargeData()
   return ret;
 }
 
+bool JoinPartition::canConvertToSplitMode()
+{
+  if (!canSplit)
+    return false;
+
+  ByteStream bs;
+  RowGroup& rg = smallRG;
+  Row& row = smallRow;
+  RGData rgData;
+  uint64_t totalRowCount = 0;
+  std::unordered_map<uint32_t, uint32_t> rowDist;
+
+  nextSmallOffset = 0;
+  while (1)
+  {
+    uint32_t hash;
+    readByteStream(0, &bs);
+
+    if (bs.length() == 0)
+      break;
+
+    rgData.deserialize(bs);
+    rg.setData(&rgData);
+
+    for (uint32_t j = 0, e = rg.getRowCount(); j < e; ++j)
+    {
+      rg.getRow(j, &row);
+
+      if (antiWithMatchNulls && hasNullJoinColumn(row))
+        continue;
+
+      uint64_t tmp;
+      if (typelessJoin)
+        hash = getHashOfTypelessKey(row, smallKeyCols, hashSeed) % bucketCount;
+      else
+      {
+        if (UNLIKELY(row.isUnsigned(smallKeyCols[0])))
+          tmp = row.getUintField(smallKeyCols[0]);
+        else
+          tmp = row.getIntField(smallKeyCols[0]);
+
+        hash = hasher((char*)&tmp, 8, hashSeed);
+        hash = hasher.finalize(hash, 8) % bucketCount;
+      }
+
+      totalRowCount++;
+      rowDist[hash]++;
+    }
+  }
+
+  for (const auto& [hash, currentRowCount] : rowDist)
+  {
+    if (currentRowCount == totalRowCount)
+    {
+      canSplit = false;
+      break;
+    }
+  }
+
+  rg.setData(&buffer);
+  rg.resetRowGroup(0);
+  rg.getRow(0, &row);
+
+  return canSplit;
+}
+
 int64_t JoinPartition::convertToSplitMode()
 {
-  int i, j;
+#ifdef DEBUG_DJS
+  cout << "Convert to split mode " << endl;
+#endif
   ByteStream bs;
   RGData rgData;
   uint32_t hash;
   uint64_t tmp;
   int64_t ret = -(int64_t)smallSizeOnDisk;  // smallFile gets deleted
-  boost::scoped_array<uint32_t> rowDist(new uint32_t[bucketCount]);
-  uint32_t rowCount = 0;
-
-  memset(rowDist.get(), 0, sizeof(uint32_t) * bucketCount);
   fileMode = false;
+
   htSizeEstimate = 0;
   smallSizeOnDisk = 0;
-  buckets.reserve(bucketCount);
 
-  for (i = 0; i < (int)bucketCount; i++)
+  buckets.reserve(bucketCount);
+  for (uint32_t i = 0; i < bucketCount; i++)
     buckets.push_back(boost::shared_ptr<JoinPartition>(new JoinPartition(*this, false)));
 
   RowGroup& rg = smallRG;
@@ -348,7 +406,7 @@ int64_t JoinPartition::convertToSplitMode()
     rgData.deserialize(bs);
     rg.setData(&rgData);
 
-    for (j = 0; j < (int)rg.getRowCount(); j++)
+    for (uint32_t j = 0; j < rg.getRowCount(); j++)
     {
       rg.getRow(j, &row);
 
@@ -356,7 +414,7 @@ int64_t JoinPartition::convertToSplitMode()
       {
         if (needsAllNullRows || !gotNullRow)
         {
-          for (j = 0; j < (int)bucketCount; j++)
+          for (j = 0; j < bucketCount; j++)
             ret += buckets[j]->insertSmallSideRow(row);
 
           gotNullRow = true;
@@ -377,19 +435,13 @@ int64_t JoinPartition::convertToSplitMode()
         hash = hasher((char*)&tmp, 8, hashSeed);
         hash = hasher.finalize(hash, 8) % bucketCount;
       }
-
-      rowCount++;
-      rowDist[hash]++;
-      ret += buckets[hash]->insertSmallSideRow(row);
+      buckets[hash]->insertSmallSideRow(row);
     }
   }
 
+
   boost::filesystem::remove(smallFilename);
   smallFilename.clear();
-
-  for (i = 0; i < (int)bucketCount; i++)
-    if (rowDist[i] == rowCount)
-      throw IDBExcept("All rows hashed to the same bucket", ERR_DBJ_DATA_DISTRIBUTION);
 
   rg.setData(&buffer);
   rg.resetRowGroup(0);
@@ -418,30 +470,18 @@ int64_t JoinPartition::processSmallBuffer(RGData& rgData)
   int64_t ret = 0;
 
   rg.setData(&rgData);
-  // if (rootNode)
-  // cout << "smallside RGData: " << rg.toString() << endl;
 
   if (fileMode)
   {
     ByteStream bs;
     rg.serializeRGData(bs);
-    // cout << "writing RGData: " << rg.toString() << endl;
 
     ret = writeByteStream(0, bs);
-    // cout << "wrote " << ret << " bytes" << endl;
 
-    /* Check whether this partition is now too big -> convert to split mode.
-
-    The current estimate is based on 100M 4-byte rows = 4GB.  The total size is
-    the amount stored in RowGroups in mem + the size of the hash table.  The RowGroups
-    in that case use 600MB, so 3.4GB is used by the hash table.  3.4GB/100M rows = 34 bytes/row
-    */
-    htSizeEstimate += rg.getDataSize() + (34 * rg.getRowCount());
-
-    if (htSizeEstimate > htTargetSize)
+    htSizeEstimate += (64 * rg.getRowCount());
+    // Check whether this partition is now too big -> convert to split mode.
+    if (htTargetSize < htSizeEstimate && canConvertToSplitMode())
       ret += convertToSplitMode();
-
-    // cout << "wrote some data, returning " << ret << endl;
   }
   else
   {
@@ -478,19 +518,16 @@ int64_t JoinPartition::processSmallBuffer(RGData& rgData)
         hash = hasher.finalize(hash, 8) % bucketCount;
       }
 
-      // cout << "hashing smallside row: " << row.toString() << endl;
       ret += buckets[hash]->insertSmallSideRow(row);
     }
-
-    // cout << "distributed rows, returning " << ret << endl;
   }
 
   smallSizeOnDisk += ret;
   return ret;
 }
 
-/* the difference between processSmall & processLarge is mostly the names of
-   variables being small* -> large*, template? */
+// the difference between processSmall & processLarge is mostly the names of
+// variables being small* -> large*, template? */
 
 int64_t JoinPartition::processLargeBuffer()
 {
@@ -511,11 +548,8 @@ int64_t JoinPartition::processLargeBuffer(RGData& rgData)
 
   rg.setData(&rgData);
 
-  // if (rootNode)
-  //	cout << "largeside RGData: "  << rg.toString() << endl;
-
-  /* Need to fail a query with an anti join, an FE filter, and a NULL row on the
-  large side b/c it needs to be joined with the entire small side table. */
+  // Need to fail a query with an anti join, an FE filter, and a NULL row on the
+  // large side b/c it needs to be joined with the entire small side table.
   if (antiWithMatchNulls && needsAllNullRows)
   {
     rg.getRow(0, &row);
@@ -534,9 +568,7 @@ int64_t JoinPartition::processLargeBuffer(RGData& rgData)
   {
     ByteStream bs;
     rg.serializeRGData(bs);
-    // cout << "writing large RGData: " << rg.toString() << endl;
     ret = writeByteStream(1, bs);
-    // cout << "wrote " << ret << " bytes" << endl;
   }
   else
   {
@@ -560,7 +592,6 @@ int64_t JoinPartition::processLargeBuffer(RGData& rgData)
         hash = hasher.finalize(hash, 8) % bucketCount;
       }
 
-      // cout << "large side hashing row: " << row.toString() << endl;
       ret += buckets[hash]->insertLargeSideRow(row);
     }
   }
@@ -569,49 +600,18 @@ int64_t JoinPartition::processLargeBuffer(RGData& rgData)
   return ret;
 }
 
-bool JoinPartition::getNextPartition(vector<RGData>* smallData, uint64_t* partitionID, JoinPartition** jp)
+void JoinPartition::collectJoinPartitions(std::vector<JoinPartition*>& joinPartitions)
 {
   if (fileMode)
   {
-    ByteStream bs;
-    RGData rgData;
-
-    if (nextPartitionToReturn > 0)
-      return false;
-
-    // cout << "reading the small side" << endl;
-    nextSmallOffset = 0;
-
-    while (1)
-    {
-      readByteStream(0, &bs);
-
-      if (bs.length() == 0)
-        break;
-
-      rgData.deserialize(bs);
-      // smallRG.setData(&rgData);
-      // cout << "read a smallRG with " << smallRG.getRowCount() << " rows" << endl;
-      smallData->push_back(rgData);
-    }
-
-    nextPartitionToReturn = 1;
-    *partitionID = uniqueID;
-    *jp = this;
-    return true;
+    joinPartitions.push_back(this);
+    return;
   }
 
-  bool ret = false;
-
-  while (!ret && nextPartitionToReturn < bucketCount)
+  for (uint32_t currentBucket = 0; currentBucket < bucketCount; ++currentBucket)
   {
-    ret = buckets[nextPartitionToReturn]->getNextPartition(smallData, partitionID, jp);
-
-    if (!ret)
-      nextPartitionToReturn++;
+    buckets[currentBucket]->collectJoinPartitions(joinPartitions);
   }
-
-  return ret;
 }
 
 boost::shared_ptr<RGData> JoinPartition::getNextLargeRGData()
@@ -627,10 +627,7 @@ boost::shared_ptr<RGData> JoinPartition::getNextLargeRGData()
     ret->deserialize(bs);
   }
   else
-  {
-    boost::filesystem::remove(largeFilename);
-    largeSizeOnDisk = 0;
-  }
+    nextLargeOffset = 0;
 
   return ret;
 }
@@ -682,7 +679,6 @@ void JoinPartition::initForLargeSideFeed()
 
 void JoinPartition::saveSmallSidePartition(vector<RGData>& rgData)
 {
-  // cout << "JP: saving partition: " << id << endl;
   htSizeEstimate = 0;
   smallSizeOnDisk = 0;
   nextSmallOffset = 0;
@@ -806,7 +802,7 @@ uint64_t JoinPartition::writeByteStream(int which, ByteStream& bs)
 
   if (!useCompression)
   {
-    ret = len + 4;
+    ret = len + sizeof(len);
     fs.write((char*)&len, sizeof(len));
     fs.write((char*)bs.buf(), len);
     saveErrno = errno;
@@ -828,7 +824,7 @@ uint64_t JoinPartition::writeByteStream(int which, ByteStream& bs)
     boost::scoped_array<uint8_t> compressed(new uint8_t[maxSize]);
 
     compressor->compress((char*)bs.buf(), len, (char*)compressed.get(), &actualSize);
-    ret = actualSize + 4 + 8;  // sizeof (size_t) == 8. Why 4?
+    ret = actualSize + sizeof(len);  // sizeof (size_t) == 8. Why 4?
     fs.write((char*)&actualSize, sizeof(actualSize));
     // Save uncompressed len.
     fs.write((char*)&len, sizeof(len));
@@ -843,7 +839,7 @@ uint64_t JoinPartition::writeByteStream(int which, ByteStream& bs)
       throw IDBExcept(os.str().c_str(), ERR_DBJ_FILE_IO_ERROR);
     }
 
-    totalBytesWritten += sizeof(actualSize) + actualSize;
+    totalBytesWritten += sizeof(len) + actualSize;
   }
 
   bs.advance(len);


### PR DESCRIPTION
This patch:
1. Handles corner case when the bucket exceeded the memory limit, but we cannot redistribute the data in this bucket into new buckets based on a hash algorithm, because the rows have the same values.
2. Adds force option for disk join step.